### PR TITLE
A missing 'end' token caused the gem (and Thor) to fail

### DIFF
--- a/lib/upnp/control_point/device.rb
+++ b/lib/upnp/control_point/device.rb
@@ -251,6 +251,8 @@ module UPnP
 
         start_device_extraction
         start_service_extraction
+      end
+
       def extract_spec_version
         "#{@description[:root][:specVersion][:major]}.#{@description[:root][:specVersion][:minor]}"
       end


### PR DESCRIPTION
On line 254 of `lib/upnp/control_point/device.rb` a new method started without ending the previous one, which caused the following error to appear when running `thor -T`:

```
$ thor -T
Couldn't load HTTPI :em_http adapter.
WARNING: unable to load thorfile "/Users/mark/src/upnp/tasks/control_point.thor": /Users/mark/src/upnp/lib/upnp/control_point/device.rb:507: syntax error, unexpected $end, expecting keyword_end
/Users/mark/src/upnp/lib/upnp/control_point.rb:6:in `require_relative'
WARNING: unable to load thorfile "/Users/mark/src/upnp/tasks/search.thor": /Users/mark/src/upnp/lib/upnp/control_point/device.rb:507: syntax error, unexpected $end, expecting keyword_end
/Users/mark/.rvm/rubies/ruby-1.9.3-p286/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
No Thor tasks available
```
